### PR TITLE
Improve tree view with Fancytree

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -6,7 +6,7 @@
   <title>Agricheck</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jstree@3.3.14/dist/themes/default/style.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -56,13 +56,6 @@ ul.checklist input[type="checkbox"] {
 }
   
 
-/* JStree search */
-.jstree-search {
-    background: rgb(255, 255, 173) !important;
-    color: inherit  !important;
-    font-weight: normal !important;
-    font-style:  normal !important;
-}
 
 /* Agricheck navbar ------------------------------------------------------ */
 .navbar-agricheck {
@@ -79,43 +72,9 @@ ul.checklist input[type="checkbox"] {
     opacity: .8;
 }
 
-/* ------------------------------------------------------------------
-   jsTree custom checkbox states – blue tick / blue indeterminate bar
-   (selector must dig into the <a> wrapper to reach the <i>)
--------------------------------------------------------------------*/
+/* Fancytree search highlight */
+.fancytree-ext-filter span.fancytree-title.fancytree-match {
+    background: rgb(255, 255, 173);
+}
 
-/* fully-checked node: blue background + white tick */
-#tree li.jstree-checked > .jstree-anchor > .jstree-checkbox {
-    background: #0d6efd;
-    border-color: #0d6efd;
-    position: relative;
-  }
-  #tree li.jstree-checked > .jstree-anchor > .jstree-checkbox::after {
-    content: '';
-    position: absolute;
-    top: 0.15em;
-    left: 0.26em;
-    width: 0.55em;
-    height: 0.3em;
-    border: 2px solid #fff;          /* create the ✓ with borders */
-    border-top: none;
-    border-right: none;
-    transform: rotate(-45deg);
-  }
-  
-  /* half-checked (undetermined) node: blue background + white bar */
-  #tree li.jstree-undetermined > .jstree-anchor > .jstree-checkbox {
-    background: #0d6efd;
-    border-color: #0d6efd;
-    position: relative;
-  }
-  #tree li.jstree-undetermined > .jstree-anchor > .jstree-checkbox::after {
-    content: '';
-    position: absolute;
-    top: 0.44em;
-    left: 0.2em;
-    width: 0.6em;
-    height: 2px;
-    background: #fff;
-  }
   

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,8 @@
   <title>Agricheck</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jstree@3.3.14/dist/themes/default/style.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery.fancytree@2/dist/skin-awesome/ui.fancytree.min.css">
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
@@ -79,7 +80,7 @@
   <!-- Libraries -->
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/jstree@3.3.14/dist/jstree.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jquery.fancytree@2/dist/jquery.fancytree-all-deps.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/lunr/lunr.min.js"></script>
 
   <!-- Page logic -->

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -16,13 +16,13 @@ let nodeMap;                 // Map<uri, node>
 let selectedSet = new Set(); // URIs currently ticked
 
 /* -------------------------------------------------------
- *  Build jsTree data & initialise widget
+ *  Build Fancytree data & initialise widget
  * -----------------------------------------------------*/
 (async function initTree () {
   const bindings = await fetchBindings();
   nodeMap = buildNodeMap(bindings);
 
-  /* Build jsTree node for a single Collection */
+  /* Build Fancytree node for a single Collection */
   function buildNode (uri) {
     const n = nodeMap.get(uri);
 
@@ -37,10 +37,10 @@ let selectedSet = new Set(); // URIs currently ticked
     });
 
     return {
-      id:   uri,
-      text: n.label ?? uri.split('/').pop(),
-      icon: 'bi bi-collection',
-      a_attr: { 'data-search': searchParts.join(' ').toLowerCase() },
+      key: uri,
+      title: n.label ?? uri.split('/').pop(),
+      tooltip: n.comment ?? '',
+      data: { search: searchParts.join(' ').toLowerCase() },
       children: (n.subGroups ?? []).map(buildNode)
     };
   }
@@ -51,33 +51,19 @@ let selectedSet = new Set(); // URIs currently ticked
     .map(n => buildNode(n.uri));
 
   treeEl
-    .jstree({
-      plugins: ['search', 'checkbox'],
-      core: { data: roots, themes: { icons: true } },
-      checkbox: {
-        three_state: true,                      // enable half-checked state
-        cascade: 'up+down+undetermined'         // parents & children sync
-      },
-      search: {
-        show_only_matches: false,
-        search_callback(query, node) {
-          const hay = treeEl.jstree(true)
-                            .get_node(node)
-                            .a_attr['data-search'] || '';
-          return hay.includes(query.toLowerCase());
-        }
-      }
+    .fancytree({
+      extensions: ['filter'],
+      checkbox: true,
+      selectMode: 3,
+      source: roots,
+      filter: { highlight: true, autoExpand: true }
     })
-
-    /* --- update local Set whenever selection changes --- */
-    .on('changed.jstree', (_, data) => {
-      selectedSet = new Set(data.selected);
+    .on('fancytree-select', (_, data) => {
+      selectedSet = new Set(data.tree.getSelectedNodes(true).map(n => n.key));
       generateBtn.prop('disabled', selectedSet.size === 0);
     })
-
-    /* --- open node one level when it’s ticked --- */
-    .on('select_node.jstree', (_, data) => {
-      treeEl.jstree(true).open_node(data.node); // open, but no recursion
+    .on('fancytree-select', (_, data) => {
+      if (data.node.isSelected()) data.node.makeVisible();
     });
 })();
 
@@ -85,34 +71,31 @@ let selectedSet = new Set(); // URIs currently ticked
  *  Search helpers
  * -----------------------------------------------------*/
 function performSearch() {
-  const q = searchInput.val().trim();
-  const jsTree = treeEl.jstree(true);
+  const q = searchInput.val().trim().toLowerCase();
+  const tree = $.ui.fancytree.getTree(treeEl);
 
-  jsTree.clear_search();
-  jsTree.close_all();
+  tree.clearFilter();
+  tree.visit(node => node.setExpanded(false));
 
   if (!q) return;
 
-  jsTree.search(q);
+  tree.filterNodes(node => (node.data.search || '').includes(q));
 
-  // open each hit & its ancestors once
-  const { nodes: hits } = jsTree.get_search_result();
-  hits.forEach(id => {
-    const node = jsTree.get_node(id);
-    node.parents.forEach(p => { if (p !== '#') jsTree.open_node(p); });
-    jsTree.open_node(id);
-  });
+  tree.getMatchedNodes().forEach(n => n.makeVisible());
 }
 
 searchInput.on('keydown', e => { if (e.key === 'Enter') performSearch(); });
 searchBtn.on('click', performSearch);
-clearFilterBtn.on('click', () => treeEl.jstree(true).clear_search());
+clearFilterBtn.on('click', () => $.ui.fancytree.getTree(treeEl).clearFilter());
 
 /* Collapse tree & untick everything */
 foldTreeBtn.on('click', () => {
-  const jsTree = treeEl.jstree(true);
-  jsTree.deselect_all();
-  jsTree.close_all();
+  const tree = $.ui.fancytree.getTree(treeEl);
+  tree.clearFilter();
+  tree.visit(node => {
+    node.setSelected(false);
+    node.setExpanded(false);
+  });
   selectedSet.clear();
   generateBtn.prop('disabled', true);
 });


### PR DESCRIPTION
## Summary
- upgrade the tree widget on index page to use Fancytree
- drop jsTree styles and scripts
- highlight search results via Fancytree CSS
- include Font Awesome for icons

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68409f8703d08327886c58d6e276594d